### PR TITLE
add wrapper class which allows using library through a single clean i…

### DIFF
--- a/includes/TenUp/AsyncTransients/Transient_Wrapper.php
+++ b/includes/TenUp/AsyncTransients/Transient_Wrapper.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace TenUp\AsyncTransients;
+
+/**
+ * Class Transient_Wrapper
+ * @package TenUp\AsyncTransients
+ */
+class Transient_Wrapper {
+
+	protected $key;
+	protected $default_value;
+	protected $length;
+	protected $callback;
+	protected $args;
+	protected $internal_callback;
+
+	/**
+	 * Cache constructor.
+	 *
+	 * @param string $key cache key
+	 * @param mixed $default_value value to return if the cache is not yet warm
+	 * @param int $length number of seconds before value expires
+	 * @param callable $callback callback to regenerate the cache
+	 * @param array $args optional, arguments to pass into the callback
+	 */
+	public function __construct( $key, $default_value, $length, callable $callback, $args = [] ) {
+		$this->key           = $key;
+		$this->default_value = $default_value;
+		$this->length        = $length;
+		$this->args          = $args;
+		$this->set_callback( $callback );
+
+
+	}
+
+	/**
+	 * Mutator for default value
+	 *
+	 * @param $default_value
+	 */
+	public function set_default_value( $default_value ) {
+		$this->default_value = $default_value;
+	}
+
+	/**
+	 * Mutator for cache length
+	 *
+	 * @param $length
+	 */
+	public function set_length( $length ) {
+		$this->length = $length;
+	}
+
+	/**
+	 * Mutator for callback
+	 *
+	 * @param callable $callback
+	 */
+	public function set_callback( callable $callback ) {
+
+		$key    = $this->key;
+		$length = $this->length;
+		$args   = $this->args;
+
+		$this->internal_callback = function () use ( $callback, $key, $length, $args ) {
+			$value = call_user_func_array( $callback, (array) $args );
+
+			return \TenUp\AsyncTransients\set_async_transient( $key, $value, $length );
+
+
+		};
+	}
+
+	/**
+	 * Mutator for arguments
+	 *
+	 * @param array $args
+	 */
+	public function set_arguments( array $args ) {
+		$this->args = $args;
+	}
+
+	/**
+	 * If the default value is false or we get a result from the \TenUp\AsyncTransients\get_async_transient call
+	 * return it, otherwise return the default value
+	 *
+	 * @return mixed
+	 */
+	public function get() {
+
+		$value = \TenUp\AsyncTransients\get_async_transient( $this->key, $this->internal_callback,
+			(array) $this->args );
+
+		return false === $value ? $this->default_value : $value;
+	}
+}


### PR DESCRIPTION
…nterface

This is a great library, the one issue I had with it was the way the API for using this requires you to add highly specific API calls throughout your codebase. To simplify this I created a wrapper that accepts in its constructor a cache key, a default_value to return if the cache is not yet warm, the length of time to cache the object, the function to call to regenerate the cached data and optionally any arguments.

It exposes a bunch of mutators for on the fly updating of objects along with a `get` method to retrieve your data.

An example usage of this would be something like the following oversimplified example:

```
$api_call = function ( $parameter ) {

	//expensive API call simulation
	sleep( 2 );

	return $parameter . time();

};

$cache_key = 'expensive-api-call';

$async = new \TenUp\AsyncTransients\Transient_Wrapper( $cache_key, 'default-value-cache-not-yet-warm',
	MINUTE_IN_SECONDS * 60, $api_call,
	array( 'api_parameter_1' ) );


$before = microtime( true );
$val    = $async->get();
?><p>Cache value:</p>
	<pre><?php
var_dump( $val );
?></pre><?php

echo '<p>Time taken: ' . (float)( microtime( true ) - $before ) . '</p>';
```

